### PR TITLE
Add correct import order in Node.JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ Include Pixi.js and the PixiOverlay libraries:
     <script src="pixi.min.js"></script>
     <script src="L.PixiOverlay.min.js"></script>
 ```
+
+Or in Node:
+
+```js
+    import * as PIXI from "pixi.js"
+    import "leaflet-pixi-overlay" // Must be called before "leaflet"
+    import L from "leaflet"
+```
+
 Create a map:
 
 ```js


### PR DESCRIPTION
I was struggling to get it running because the import order doesn't follow the usual after-leaflet plugin load order. This adds the correct import order.