### PR TITLE
Fix issue where leaflet-pixi-overlay isn't transparent with Pixi v7

### DIFF
--- a/L.PixiOverlay.js
+++ b/L.PixiOverlay.js
@@ -85,6 +85,7 @@
 			this._drawCallback = drawCallback;
 			this._pixiContainer = pixiContainer;
 			this._rendererOptions = {
+				backgroundAlpha: 0, // PIXI v7 transparency
 				transparent: true,
 				resolution: this.options.resolution,
 				antialias: true,


### PR DESCRIPTION
When using PIXI v7 pixi overlay is rendered with black background which blocks the map. Transparent option no longer works, backgroundAlpha is used in pixi v7 example, see https://pixijs.io/examples/#/demos-basic/transparent-background.js