### PR TITLE
Fix On Remove Function

### DIFF
--- a/L.PixiOverlay.js
+++ b/L.PixiOverlay.js
@@ -388,7 +388,6 @@
 		};
 
 		pixiOverlayClass.onRemove = function () {
-			this._map = null;
 			var parent = this._container.parentNode;
 			if (parent) {
 				parent.removeChild(this._container);
@@ -397,6 +396,7 @@
 			for (var evt in events) {
 				this._map.off(evt, events[evt], this);
 			}
+			this._map = null;
 		};
 
 		pixiOverlayClass.destroy = function () {


### PR DESCRIPTION
Getting a null pointer exception in the pixiOverlayClass.onRemove function

-set ._map to null after events .off function is called